### PR TITLE
Include :provided profile when compiling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-uberwar "0.1.0"
+(defproject lein-uberwar "0.2.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "https://github.com/yogthos/lein-uberwar"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/war.clj
+++ b/src/leiningen/war.clj
@@ -232,7 +232,7 @@
                         (unmerge-profiles [:default])
                         (merge-profiles profiles-to-merge)
                         add-servlet-dep)
-           result  (compile/compile project)]
+           result (compile/compile (merge-profiles project [:provided]))]
        (when-not (and (number? result) (pos? result))
          (let [war-path (war-file-path project war-name)]
            (compile-servlet project)


### PR DESCRIPTION
The :provided profile designates dependencies that are to be excluded
from uberjars.  This change also implements the exclusion for uberwars.
It is compatible with the horrible logic carried over from lein-ring
that excludes any jars from the uberjar that provide the servlet
interface, but it allows for additional jars to be excluded, e.g.:

```
:profiles {:provided {:dependencies [[javax.servlet/javax.servlet-api "3.1.0"]
                                     [log4j/log4j "1.2.17"]
                                     [org.camunda.bpm/camunda-engine "7.4.0"]]}}
```

Would make the listed dependencies available when compiling for the .war
file, but not include them in the uberwar.
